### PR TITLE
Avoid creating default channel

### DIFF
--- a/src/android/notification/Manager.java
+++ b/src/android/notification/Manager.java
@@ -72,7 +72,7 @@ public final class Manager {
      */
     private Manager(Context context) {
         this.context = context;
-        createDefaultChannel();
+        // createDefaultChannel();
     }
 
     /**


### PR DESCRIPTION
Avoid creating the channel named "Default channel". This is confusing for the user. We should always add the channel in the notification payload.